### PR TITLE
Redmine 5.0 and zeitwerk compatibility

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with redmine_custom_css.  If not, see <http://www.gnu.org/licenses/>.
 #
-require_dependency 'hooks'
+require File.expand_path 'lib/redmine_custom_css/hook_listener', __dir__
 
 Redmine::Plugin.register :redmine_custom_css do
   name 'Redmine Custom CSS plugin'

--- a/lib/redmine_custom_css.rb
+++ b/lib/redmine_custom_css.rb
@@ -1,0 +1,2 @@
+module RedmineCustomCss
+end

--- a/lib/redmine_custom_css/hook_listener.rb
+++ b/lib/redmine_custom_css/hook_listener.rb
@@ -19,7 +19,7 @@
 # along with redmine_custom_css.  If not, see <http://www.gnu.org/licenses/>.
 #
 module RedmineCustomCss
-  class RedmineCustomCssHookListener < Redmine::Hook::ViewListener
+  class HookListener < Redmine::Hook::ViewListener
     def view_layouts_base_html_head(context)
       css = Setting.plugin_redmine_custom_css['css']
       "<style type=\"text/css\">#{css}</style>" unless css.nil? or css.empty?


### PR DESCRIPTION
In the latest stable release redmine moved to zeitwerk code loader. Current version of plugin doesn't work with it. PR adds support for redmine 5.0.